### PR TITLE
feat: clickable next page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [1.29.0] - 2026-04-26
+
+### Changed
+
+- Clicking on the "new posts on new page" indicator now links to the next page
+ 
 ## [1.28.1] - 2026-03-29
 
 ### Fixed

--- a/app/assets/changelog/changelog.ts
+++ b/app/assets/changelog/changelog.ts
@@ -1,5 +1,12 @@
 export const changelog: ChangelogItem[] = [
   {
+    version: '1.29.0',
+    type: 'minor',
+    changed: [
+      'Die "Neue Posts auf neuer Seite"-Anzeige ist nun klickbar und navigiert direkt zur nächsten Seite.',
+    ],
+  },
+  {
     version: '1.28.1',
     type: 'patch',
     fixed: [

--- a/app/components/routes/thread/page/index.gts
+++ b/app/components/routes/thread/page/index.gts
@@ -82,7 +82,11 @@ export default class ThreadPage extends Component<Signature> {
                 @subtle={{this.isPostSubtle post}}
               />
               {{#if (eq @lastReadPost post.id)}}
-                <UnreadPostsSeparator @post={{post}} @posts={{this.posts}} />
+                <UnreadPostsSeparator
+                  @post={{post}}
+                  @posts={{this.posts}}
+                  @thread={{this.thread}}
+                />
               {{/if}}
               {{#if (isFinalElement post this.posts)}}
                 <UpdateScrollPosition />

--- a/app/components/routes/thread/unread-posts-separator/index.gts
+++ b/app/components/routes/thread/unread-posts-separator/index.gts
@@ -1,5 +1,7 @@
+import { LinkTo } from '@ember/routing';
 import Component from '@glimmer/component';
 import type Post from 'potber-client/models/post';
+import type Thread from 'potber-client/models/thread';
 import styles from './styles.module.css';
 import classNames from 'potber-client/helpers/class-names';
 
@@ -7,16 +9,41 @@ interface Signature {
   Args: {
     post: Post;
     posts: Post[];
+    thread: Thread;
   };
 }
 
 export default class UnreadPostsSeparator extends Component<Signature> {
   styles = styles;
 
+  get hasUnreadPostsOnNextPage() {
+    const { post, posts, thread } = this.args;
+    const page = thread.page;
+
+    if (!page) return false;
+
+    return (
+      posts.indexOf(post) === posts.length - 1 &&
+      page.number < thread.pagesCount
+    );
+  }
+
+  get nextPageQuery() {
+    const nextPage = this.args.thread.page?.number
+      ? this.args.thread.page.number + 1
+      : undefined;
+
+    return {
+      TID: this.args.thread.id,
+      page: nextPage,
+      PID: undefined,
+      lastReadPost: undefined,
+      scrollToBottom: undefined,
+    };
+  }
+
   get text() {
-    const { post, posts } = this.args;
-    const index = posts.indexOf(post);
-    if (index >= 29) {
+    if (this.hasUnreadPostsOnNextPage) {
       return 'Neue Posts auf der nächsten Seite';
     } else return 'Neue Posts';
   }
@@ -24,7 +51,19 @@ export default class UnreadPostsSeparator extends Component<Signature> {
   <template>
     <span class={{classNames this 'separator'}}>
       <hr />
-      <p>{{this.text}}
+      <p>
+        {{#if this.hasUnreadPostsOnNextPage}}
+          <LinkTo
+            @route='authenticated.thread'
+            @query={{this.nextPageQuery}}
+            class={{classNames this 'text-link'}}
+            title='Zur nächsten Seite'
+          >
+            {{this.text}}
+          </LinkTo>
+        {{else}}
+          {{this.text}}
+        {{/if}}
       </p>
     </span>
   </template>

--- a/app/components/routes/thread/unread-posts-separator/styles.module.css
+++ b/app/components/routes/thread/unread-posts-separator/styles.module.css
@@ -17,3 +17,9 @@
     position: absolute;
   }
 }
+
+.text-link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 0.15rem;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "potber-client",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "potber-client",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "license": "GNU General Public License",
       "dependencies": {
         "@appsignal/ember": "^1.0.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "potber-client",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "private": true,
   "description": "An SPA client for the german board forum.mods.de built with Ember.js.",
   "repository": "https://github.com/potber/potber-client",

--- a/tests/integration/components/routes/thread/unread-posts-separator-test.ts
+++ b/tests/integration/components/routes/thread/unread-posts-separator-test.ts
@@ -1,0 +1,87 @@
+import { render } from '@ember/test-helpers';
+import type { TestContext } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, test } from 'qunit';
+import type Post from 'potber-client/models/post';
+import type Thread from 'potber-client/models/thread';
+import { setupRenderingTest } from 'potber-client/tests/helpers';
+
+interface Context extends TestContext {
+  element: HTMLElement;
+  post: Post;
+  posts: Post[];
+  thread: Thread;
+}
+
+function createPosts(count: number): Post[] {
+  return Array.from({ length: count }, (_, index) => {
+    return { id: `${index + 1}` } as Post;
+  });
+}
+
+function createThread(posts: Post[], pageNumber = 1, pagesCount = 2): Thread {
+  return {
+    id: '219289',
+    title: 'potber',
+    boardId: '14',
+    repliesCount: 0,
+    hitsCount: 0,
+    pagesCount,
+    isClosed: false,
+    isSticky: false,
+    isImportant: false,
+    isAnnouncement: false,
+    isGlobal: false,
+    page: {
+      number: pageNumber,
+      offset: (pageNumber - 1) * posts.length,
+      postCount: posts.length,
+      posts,
+    },
+  };
+}
+
+module(
+  'Integration | Component | Routes | Thread | Unread posts separator',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('renders plain text when unread posts continue on the current page', async function (this: Context, assert) {
+      const posts = createPosts(30);
+      this.set('posts', posts);
+      this.set('post', posts[10] as Post);
+      this.set('thread', createThread(posts));
+
+      await render<Context>(hbs`
+        <Routes::Thread::UnreadPostsSeparator
+          @post={{this.post}}
+          @posts={{this.posts}}
+          @thread={{this.thread}}
+        />
+      `);
+
+      assert.dom('p').hasText('Neue Posts');
+      assert.dom('a').doesNotExist();
+    });
+
+    test('links to the next page when unread posts start there', async function (this: Context, assert) {
+      const posts = createPosts(30);
+      this.set('posts', posts);
+      this.set('post', posts[29] as Post);
+      this.set('thread', createThread(posts));
+
+      await render<Context>(hbs`
+        <Routes::Thread::UnreadPostsSeparator
+          @post={{this.post}}
+          @posts={{this.posts}}
+          @thread={{this.thread}}
+        />
+      `);
+
+      assert.dom('a').hasText('Neue Posts auf der nächsten Seite');
+      const href = this.element.querySelector('a')?.getAttribute('href') ?? '';
+      assert.true(href.includes('TID=219289'), 'links to the current thread');
+      assert.true(href.includes('page=2'), 'links to the next page');
+    });
+  },
+);

--- a/types/glint.registry.d.ts
+++ b/types/glint.registry.d.ts
@@ -5,6 +5,7 @@ import AccordionComponent from 'potber-client/components/common/control/accordio
 import PrivateMessageListComponent from 'potber-client/components/features/private-messages/list';
 import ModalComponent from 'potber-client/components/modal';
 import NavComponent from 'potber-client/components/nav';
+import UnreadPostsSeparatorComponent from 'potber-client/components/routes/thread/unread-posts-separator';
 
 declare module '@glint/environment-ember-loose/registry' {
   export default interface Registry {
@@ -12,5 +13,6 @@ declare module '@glint/environment-ember-loose/registry' {
     'Features::PrivateMessages::List': typeof PrivateMessageListComponent;
     Modal: typeof ModalComponent;
     Nav: typeof NavComponent;
+    'Routes::Thread::UnreadPostsSeparator': typeof UnreadPostsSeparatorComponent;
   }
 }


### PR DESCRIPTION
## Summary

Make the unread posts separator clickable when unread posts start on the next thread page.

## What changed

- link `Neue Posts auf der nächsten Seite` to the next thread page
- keep `Neue Posts` as plain text when unread posts are still on the current page
- add a focused integration test for both states
- register the component for Glint template typing

## Testing

- `npm run lint:types`
- `npx eslint app/components/routes/thread/unread-posts-separator/index.gts app/components/routes/thread/page/index.gts tests/integration/components/routes/thread/unread-posts-separator-test.ts types/glint.registry.d.ts`
- `TESTEM_BROWSER='headless chrome' npm run test:ember -- --filter="Unread posts separator"`
