### PR TITLE
fix: update GitHub link in about.hbs to point to the correct repository

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -28,7 +28,7 @@
 
   <a
     class='button-link control-size-large control-variant-primary margin-vertical-x-small'
-    href='https://github.com/spuxx-dev/potber-client'
+    href='https://github.com/potber/potber-client'
     target='_blank'
     rel='noopener noreferrer'
   >


### PR DESCRIPTION
Auf der About Seite wird auch noch auf „Ameisenfutter” verwiesen. Ich war mir aber nicht sicher, ob man das als „Legacy” behalten möchte.

Auf das neue Git-Repository zu verweisen, finde ich dennoch sinnvoll.