### PR TITLE
Add v1.29.3 in-app changelog note

### DIFF
--- a/app/assets/changelog/changelog.ts
+++ b/app/assets/changelog/changelog.ts
@@ -1,5 +1,12 @@
 export const changelog: ChangelogItem[] = [
   {
+    version: '1.29.3',
+    type: 'patch',
+    changed: [
+      'Die Symbolleiste im Postformular wurde auf das bisherige Layout zurückgesetzt.',
+    ],
+  },
+  {
     version: '1.29.2',
     type: 'patch',
     fixed: [


### PR DESCRIPTION
## Summary

Adds the missing in-app changelog entry for version 1.29.3.

## Why

The rollback release updated the repository changelog, but the changelog shown inside potber still ended at version 1.29.2.

## User impact

The version dialog now explains that the post composer toolbar was restored to its previous layout.

## Validation

- `mise exec node@24 -- npm run lint`
- `git diff --check`